### PR TITLE
Ensure admin login returns permissions and verify storage

### DIFF
--- a/backend/src/__tests__/admin.test.ts
+++ b/backend/src/__tests__/admin.test.ts
@@ -247,7 +247,9 @@ describe('Admin routes', () => {
       .send({ email: adminUsers[0]!.email, password });
 
     expect(response.status).toBe(200);
-    const { token } = response.body as { token: string };
+    const { token, user } = response.body as { token: string; user: { permissions?: string[] } };
+    expect(Array.isArray(user?.permissions)).toBe(true);
+    expect(user?.permissions).toContain('admin:access');
     return token;
   };
 
@@ -257,7 +259,15 @@ describe('Admin routes', () => {
       .send({ email: adminUsers[0]!.email, password });
 
     expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('token');
+    expect(response.body).toMatchObject({
+      token: expect.any(String),
+      user: {
+        id: adminUsers[0]!.id,
+        email: adminUsers[0]!.email,
+        name: adminUsers[0]!.name,
+        permissions: expect.arrayContaining(['admin:access']),
+      },
+    });
     expect(sessions).toHaveLength(1);
   });
 

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -86,10 +86,12 @@ adminRouter.post(
 
     return res.json({
       token: jwtToken,
-      admin: {
+      user: {
         id: admin.id,
         email: admin.email,
         name: admin.name,
+        roles: ['admin'],
+        permissions: ['admin:access'],
       },
     });
   })

--- a/frontend/scripts/verify-login-storage.ts
+++ b/frontend/scripts/verify-login-storage.ts
@@ -1,0 +1,76 @@
+import { persistAuthState, TOKEN_STORAGE_KEY, USER_STORAGE_KEY, type AuthUser } from "../src/hooks/useAuth.tsx";
+
+interface StorageLike {
+  length: number;
+  clear(): void;
+  getItem(key: string): string | null;
+  key(index: number): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+class MemoryStorage implements StorageLike {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+}
+
+const storage = new MemoryStorage();
+
+const user: AuthUser = {
+  id: "admin-1",
+  email: "admin@example.com",
+  name: "Admin User",
+  permissions: ["admin:access"],
+};
+
+persistAuthState(storage as unknown as Storage, "test-token", user);
+
+const storedToken = storage.getItem(TOKEN_STORAGE_KEY);
+if (storedToken !== "test-token") {
+  throw new Error(`Token not persisted correctly: ${storedToken ?? "<missing>"}`);
+}
+
+const storedUserRaw = storage.getItem(USER_STORAGE_KEY);
+if (!storedUserRaw) {
+  throw new Error("User payload was not persisted");
+}
+
+const storedUser = JSON.parse(storedUserRaw) as AuthUser;
+if (!Array.isArray(storedUser.permissions) || !storedUser.permissions.includes("admin:access")) {
+  throw new Error(`Stored user is missing required permissions: ${storedUserRaw}`);
+}
+
+const hasAdminAccess = (permission: string) =>
+  Array.isArray(storedUser.permissions) &&
+  storedUser.permissions.some((value) => value.toLowerCase() === permission.toLowerCase());
+
+if (!hasAdminAccess("admin:access")) {
+  throw new Error("Permission gate would block admin access after login");
+}
+
+console.log("Stored token:", storedToken);
+console.log("Stored user payload:", storedUser);
+console.log("Admin permission granted:", hasAdminAccess("admin:access"));


### PR DESCRIPTION
## Summary
- update the admin login route to emit a `user` payload that carries id, contact info, roles, and the required `admin:access` permission
- extend the admin route tests to assert the new response shape and the presence of admin permissions
- expose a reusable auth persistence helper and add a small script that verifies the stored user retains the admin permission for the frontend

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`
- `NODE_PATH=frontend/node_modules:backend/node_modules TS_NODE_PROJECT=frontend/tsconfig.app.json node --loader ./backend/node_modules/ts-node/esm.mjs frontend/scripts/verify-login-storage.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d336ac55748326bf719dc3cd622b8a