### PR TITLE
Fix prisma schema configuration

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,6 +6,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  schemas  = ["site_quantum"]
 }
 
 model AdminUser {


### PR DESCRIPTION
## Summary
- configure the Prisma datasource to include the `site_quantum` schema so models using @@schema validate correctly

## Testing
- npm run prisma:generate

------
https://chatgpt.com/codex/tasks/task_e_68d341c59c988326aa6e35a998a50524