### PR TITLE
Fix dev server startup and type issues

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -10,16 +10,15 @@ const config: Config = {
         tsconfig: './tsconfig.json',
       },
     ],
-
   },
   moduleNameMapper: {
-    '^(\.\.?/.*)\.js$': '$1',
+    '^(\\.\\.?/.*)\\.js$': '$1',
   },
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/index.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'cjs', 'json', 'node'],
-
 };
 
 export default config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node --loader ts-node/esm --watch src/index.ts",
+    "dev": "node scripts/dev-server.mjs",
 
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",

--- a/backend/scripts/dev-server.mjs
+++ b/backend/scripts/dev-server.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { watch } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const SRC_DIR = path.resolve(process.cwd(), 'src');
+const ENTRY_FILE = path.resolve(SRC_DIR, 'index.ts');
+
+let childProcess = null;
+let pendingRestart = false;
+let restartTimer = null;
+
+const log = (message) => {
+  const timestamp = new Date().toISOString();
+  console.log(`[dev ${timestamp}] ${message}`);
+};
+
+const startServer = () => {
+  childProcess = spawn(process.execPath, ['--loader', 'ts-node/esm', ENTRY_FILE], {
+    stdio: 'inherit',
+  });
+
+  childProcess.on('exit', (code, signal) => {
+    const requestedRestart = pendingRestart;
+    pendingRestart = false;
+
+    if (requestedRestart) {
+      startServer();
+      return;
+    }
+
+    if (signal) {
+      log(`server exited due to signal ${signal}`);
+    } else if (code !== 0) {
+      log(`server exited with code ${code}`);
+    }
+  });
+
+  childProcess.on('error', (error) => {
+    log(`failed to start server: ${error.message}`);
+  });
+
+  log('development server started');
+};
+
+const stopServer = () => {
+  if (!childProcess) {
+    return;
+  }
+
+  const terminated = childProcess.kill('SIGTERM');
+  if (!terminated) {
+    pendingRestart = false;
+  }
+};
+
+const restartServer = () => {
+  if (!childProcess || childProcess.killed) {
+    startServer();
+    return;
+  }
+
+  pendingRestart = true;
+  stopServer();
+};
+
+const scheduleRestart = (filePath) => {
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+  }
+
+  restartTimer = setTimeout(() => {
+    restartTimer = null;
+    log(`change detected in ${path.relative(process.cwd(), filePath)} - restarting`);
+    restartServer();
+  }, 150);
+};
+
+const watchers = new Map();
+
+const closeWatcher = (dir) => {
+  const watcher = watchers.get(dir);
+  if (watcher) {
+    watcher.close();
+    watchers.delete(dir);
+  }
+};
+
+const closeDescendantWatchers = (dir) => {
+  for (const watchedDir of Array.from(watchers.keys())) {
+    if (watchedDir.startsWith(dir)) {
+      closeWatcher(watchedDir);
+    }
+  }
+};
+
+const watchDirectory = async (dir) => {
+  if (watchers.has(dir)) {
+    return;
+  }
+
+  const watcher = watch(dir, { persistent: true }, async (eventType, filename) => {
+    if (!filename) {
+      return;
+    }
+
+    const name = filename.toString();
+    const fullPath = path.join(dir, name);
+
+    if (fullPath.endsWith('.ts') || fullPath.endsWith('.tsx')) {
+      scheduleRestart(fullPath);
+    }
+
+    if (eventType === 'rename') {
+      try {
+        const fileStats = await stat(fullPath);
+        if (fileStats.isDirectory()) {
+          await watchDirectory(fullPath);
+        }
+      } catch (error) {
+        if (error && error.code === 'ENOENT') {
+          closeDescendantWatchers(fullPath + path.sep);
+        }
+      }
+    }
+  });
+
+  watchers.set(dir, watcher);
+
+  const entries = await readdir(dir, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => watchDirectory(path.join(dir, entry.name))),
+  );
+};
+
+const bootstrap = async () => {
+  await watchDirectory(SRC_DIR);
+  startServer();
+};
+
+const shutdown = () => {
+  for (const watcher of watchers.values()) {
+    watcher.close();
+  }
+  watchers.clear();
+
+  if (childProcess) {
+    childProcess.kill('SIGTERM');
+  }
+};
+
+process.on('SIGINT', () => {
+  shutdown();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  shutdown();
+  process.exit(0);
+});
+
+bootstrap().catch((error) => {
+  log(`failed to start watcher: ${error.message}`);
+  process.exit(1);
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,4 @@
-import cors, { CorsOptions } from 'cors';
+import cors, { type CorsCallback } from './lib/cors.js';
 import express from 'express';
 
 import { env } from './config/env.js';
@@ -8,8 +8,8 @@ import { adminRouter } from './routes/admin.js';
 export const createApp = () => {
   const app = express();
 
-  const corsOptions: CorsOptions = {
-    origin: (origin, callback) => {
+  const corsOptions = {
+    origin: (origin: string | undefined, callback: CorsCallback) => {
       if (!origin || env.corsAllowedOrigins.includes('*')) {
         return callback(null, true);
       }

--- a/backend/src/global.d.ts
+++ b/backend/src/global.d.ts
@@ -1,0 +1,30 @@
+import type { AdminUser } from '@prisma/client';
+import type { RequestHandler } from 'express';
+
+declare module 'cors' {
+  type CorsOptionsDelegate = (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => void;
+
+  interface CorsOptions {
+    origin?: boolean | string | RegExp | (string | RegExp)[] | CorsOptionsDelegate;
+  }
+
+  type CorsMiddleware = (options?: CorsOptions) => RequestHandler;
+
+  const cors: CorsMiddleware;
+  export default cors;
+}
+
+declare module 'cors/lib/index.js' {
+  import cors from 'cors';
+  export default cors;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      admin?: Pick<AdminUser, 'id' | 'email' | 'name'> & { sessionId: string };
+    }
+  }
+}
+
+export {};

--- a/backend/src/lib/cors.ts
+++ b/backend/src/lib/cors.ts
@@ -1,0 +1,23 @@
+import { createRequire } from 'node:module';
+import type { RequestHandler } from 'express';
+
+const require = createRequire(import.meta.url);
+
+export type CorsCallback = (err: Error | null, allow?: boolean) => void;
+
+export type CorsOptionsDelegate = (
+  origin: string | undefined,
+  callback: CorsCallback,
+) => void;
+
+export interface CorsOptions {
+  origin?: boolean | string | RegExp | Array<string | RegExp> | CorsOptionsDelegate;
+}
+
+export type CorsMiddleware = (options?: CorsOptions) => RequestHandler;
+
+const corsModule = require('cors') as unknown;
+
+const cors = corsModule as CorsMiddleware;
+
+export default cors;

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import type { AnyZodObject, ZodError } from 'zod';
+import type { AnyZodObject } from 'zod';
+import { ZodError } from 'zod';
 
 export const validateBody = (schema: AnyZodObject) =>
   (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/types/cors.d.ts
+++ b/backend/src/types/cors.d.ts
@@ -1,1 +1,0 @@
-declare module 'cors';

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -1,9 +1,0 @@
-import type { AdminUser } from '@prisma/client';
-
-declare global {
-  namespace Express {
-    interface Request {
-      admin?: Pick<AdminUser, 'id' | 'email' | 'name'> & { sessionId: string };
-    }
-  }
-}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,5 +15,6 @@
     "types": ["node", "jest"]
   },
   "include": ["src"],
+  "files": ["src/global.d.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- replace the Node.js `--watch` invocation with a dedicated dev-server script that restarts `ts-node` on TypeScript file changes
- add TypeScript shims for Express and CORS usage so runtime types are available without relying on ambient modules
- update project configuration to load the new shims and keep Jest from traversing the compiled `dist` output

## Testing
- npm run build
- npm run dev
- npm test *(fails: SyntaxError from Jest when parsing ESM test files)*

------
https://chatgpt.com/codex/tasks/task_e_68d34388182083268056322716d73fc9